### PR TITLE
fix: use migrate:fresh in staging deployment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
             composer install --no-interaction --prefer-dist --optimize-autoloader
 
             # Run migrations
-            php artisan migrate:refresh --seed
+            php artisan migrate:fresh --seed --force
 
             # Clear and rebuild caches
             php artisan config:cache


### PR DESCRIPTION
## Summary
- Fix staging CI/CD deployment failure caused by `migrate:refresh` hitting duplicate table error on Spatie `media` table
- Changed to `migrate:fresh --seed --force` which drops all tables first, avoiding the issue

## Test plan
- [ ] Merge PR and verify GitHub Actions deployment succeeds
- [ ] Confirm staging database is freshly migrated and seeded